### PR TITLE
Update PyTorch package to the latest 1.9.0 release

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-base-ubuntu20.04
+FROM nvidia/cuda:11.1-base-ubuntu20.04
 # adapated from build file for pangeo images
 # https://github.com/pangeo-data/pangeo-docker-images
 

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -1,6 +1,7 @@
 name: condaenv
 channels:
  - conda-forge
+ - pytorch
  - fastai
 dependencies:
 ###############################
@@ -44,8 +45,9 @@ dependencies:
 # deep learning         #
 #########################
  - fastai
- - pytorch-cpu
- - torchvision-cpu
+ - pytorch
+ - torchvision
+ - cpuonly
  - pytorch-lightning
  - segmentation-models-pytorch
  - albumentations

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -22,7 +22,7 @@ dependencies:
   - pygeos=0.10.1
   - pytest=6.2.4
   - python=3.9.6
-  - pytorch-cpu=1.9.0
+  - pytorch=1.9.0
   - cpuonly # This package forces installation of pytorch without GPU support
   - libprotobuf<3.17.0a0
   - pytorch-lightning=1.4.1

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -1,6 +1,7 @@
 name: condaenv
 channels:
   - fastai
+  - pytorch
   - conda-forge
 dependencies:
   - albumentations=1.0.3
@@ -21,7 +22,8 @@ dependencies:
   - pygeos=0.10.1
   - pytest=6.2.4
   - python=3.9.6
-  - pytorch-cpu=1.8.0
+  - pytorch-cpu=1.9.0
+  - cpuonly # This package forces installation of pytorch without GPU support
   - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2
@@ -33,7 +35,7 @@ dependencies:
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
-  - torchvision=0.9.1
+  - torchvision=0.10.0
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -24,7 +24,7 @@ dependencies:
   - python=3.9.6
   - pytorch-cpu=1.9.0
   - cpuonly # This package forces installation of pytorch without GPU support
-  - libprotobuf
+  - libprotobuf<3.17.0a0
   - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -1,11 +1,8 @@
 name: condaenv
 channels:
-  - fastai
-  - pytorch
   - conda-forge
 dependencies:
   - albumentations=1.0.3
-  - fastai=2.5.0
   - geos=3.9.1
   - geotiff=1.6.0
   - h5py=2.10.0
@@ -22,23 +19,23 @@ dependencies:
   - pygeos=0.10.1
   - pytest=6.2.4
   - python=3.9.6
-  - pytorch=1.9.0
-  - cpuonly # This package forces installation of pytorch without GPU support
-  - libprotobuf<3.17.0a0
-  - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2
   - scikit-learn=0.24.2
   - scipy=1.7.1
-  - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
   - tensorflow=2.4.1
   - tifffile=2021.8.8
   - tiledb=2.3.2
-  - timm=0.4.12
-  - torchvision=0.10.0
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
   - pip:
+    - -f https://download.pytorch.org/whl/torch_stable.html
+    - fastai==2.5.0
     - ttach==0.0.3
+    - segmentation-models-pytorch==0.2.0
+    - pytorch-lightning==1.4.1
+    - timm==0.4.12
+    - torch==1.9.0+cpu
+    - torchvision==0.10.0+cpu

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -24,6 +24,7 @@ dependencies:
   - python=3.9.6
   - pytorch-cpu=1.9.0
   - cpuonly # This package forces installation of pytorch without GPU support
+  - libprotobuf
   - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -1,6 +1,7 @@
 name: condaenv
 channels:
  - conda-forge
+ - pytorch
  - fastai
 dependencies:
 ###############################

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -1,14 +1,8 @@
 name: condaenv
 channels:
-  - fastai
-  - pytorch
-  - nvidia
   - conda-forge
 dependencies:
   - albumentations=1.0.3
-  - cudatoolkit=11.1
-  - cudnn=8.2
-  - fastai=2.5.0
   - geos=3.9.1
   - geotiff=1.6.0
   - h5py=2.10.0
@@ -25,21 +19,23 @@ dependencies:
   - pygeos=0.10.1
   - pytest=6.2.4
   - python=3.9.6
-  - pytorch=1.9.0
-  - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2
   - scikit-learn=0.24.2
   - scipy=1.7.1
-  - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
   - tensorflow=2.4.1
   - tifffile=2021.8.8
   - tiledb=2.3.2
-  - timm=0.4.12
-  - torchvision=0.10.0
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0
   - pip:
+    - -f https://download.pytorch.org/whl/torch_stable.html
+    - fastai==2.5.0
     - ttach==0.0.3
+    - segmentation-models-pytorch==0.2.0
+    - pytorch-lightning==1.4.1
+    - timm==0.4.12
+    - torch==1.9.0+cu111
+    - torchvision==0.10.0+cu111

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -1,12 +1,13 @@
 name: condaenv
 channels:
   - fastai
+  - pytorch
   - nvidia
   - conda-forge
 dependencies:
   - albumentations=1.0.3
-  - cudatoolkit=11.1.74=h6bb024c_0
-  - cudnn=8.2.1.32=h86fa8c9_0
+  - cudatoolkit=11.1
+  - cudnn=8.2
   - fastai=2.5.0
   - geos=3.9.1
   - geotiff=1.6.0
@@ -24,7 +25,7 @@ dependencies:
   - pygeos=0.10.1
   - pytest=6.2.4
   - python=3.9.6
-  - pytorch=1.8.0=cuda111py39h37e5b68_1
+  - pytorch=1.9.0
   - pytorch-lightning=1.4.1
   - rasterio=1.2.6
   - scikit-image=0.18.2
@@ -32,11 +33,11 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - tensorflow=2.4.1=py39hf3d152e_0
+  - tensorflow=2.4.1
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
-  - torchvision=0.9.1=py39cuda111hcd06603_1_cuda
+  - torchvision=0.10.0
   - tqdm=4.62.0
   - typer=0.3.2
   - xarray=0.19.0


### PR DESCRIPTION
Hi! This PR adds the latest PyTorch 1.9.0 package to both CPU & GPU environments. 

The motivation of this PR is that there were a few major BC since 1.8 -> 1.9. In particular, `torch.jit.tracing`  behavior changed, so that models traced in PyTorch 1.9 cannot be used in PyTorch 1.8 environment. 