### PR TITLE
Install tensorflow with pip for GPU

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -30,7 +30,6 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - tensorflow=2.4.1
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -42,3 +41,4 @@ dependencies:
     - ttach==0.0.3
     - mmcv==1.3.0
     - mmsegmentation==0.11.0
+    - tensorflow-cpu==2.6.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -33,7 +33,6 @@ dependencies:
   - scipy=1.7.1
   - segmentation-models-pytorch=0.2.0
   - shapely=1.7.1
-  - tensorflow=2.4.1=py39hf3d152e_0
   - tifffile=2021.8.8
   - tiledb=2.3.2
   - timm=0.4.12
@@ -45,3 +44,4 @@ dependencies:
     - ttach==0.0.3
     - mmcv-full==1.3.0
     - mmsegmentation==0.11.0
+    - tensorflow-gpu==2.6.0

--- a/runtime/tests/test_packages.py
+++ b/runtime/tests/test_packages.py
@@ -1,6 +1,10 @@
 # adapted from pangeo https://github.com/pangeo-data/pangeo-docker-images/blob/master/tests/test_pangeo-notebook.py
-import pytest
 import importlib
+import subprocess
+import warnings
+
+import pytest
+
 
 packages = [
     # these are problem libraries that don't always seem to import, mostly due
@@ -20,3 +24,17 @@ packages = [
 @pytest.mark.parametrize("package_name", packages, ids=packages)
 def test_import(package_name):
     importlib.import_module(package_name)
+
+def test_gpu_packages():
+    try:
+        subprocess.check_call(["nvidia-smi"])
+
+        import torch
+        assert torch.cuda.is_available()
+
+        import tensorflow as tf
+        assert tf.test.is_built_with_cuda()
+        assert tf.config.list_physical_devices('GPU')
+
+    except FileNotFoundError:
+        warnings.warn("Skipping GPU import tests since nvidia-smi is not present on test machine.")


### PR DESCRIPTION
Uses `pip` to install tensorflow since that properly can use CPU/GPU.

Adds test if running on GPU machine to ensure tensorflow and torch can see the GPU (confirmed working locally).