### PR TITLE
Update mmsegmentation from 0.11.0 to 0.16.0

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -39,6 +39,6 @@ dependencies:
   - xarray=0.19.0
   - pip:
     - ttach==0.0.3
-    - mmcv==1.3.0
-    - mmsegmentation==0.11.0
+    - mmcv==1.3.1
+    - mmsegmentation==0.16.0
     - tensorflow-cpu==2.6.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -39,6 +39,6 @@ dependencies:
   - xarray=0.19.0
   - pip:
     - ttach==0.0.3
-    - mmcv==1.3.1
+    - mmcv==1.3.9
     - mmsegmentation==0.16.0
     - tensorflow-cpu==2.6.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -42,6 +42,6 @@ dependencies:
   - xarray=0.19.0
   - pip:
     - ttach==0.0.3
-    - mmcv-full==1.3.1
+    - mmcv-full==1.3.9
     - mmsegmentation==0.16.0
     - tensorflow-gpu==2.6.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -42,6 +42,6 @@ dependencies:
   - xarray=0.19.0
   - pip:
     - ttach==0.0.3
-    - mmcv-full==1.3.0
-    - mmsegmentation==0.11.0
+    - mmcv-full==1.3.1
+    - mmsegmentation==0.16.0
     - tensorflow-gpu==2.6.0


### PR DESCRIPTION
mmsegmentation 0.11.0 have some bugs and mmsegmentation 0.16.0 support more features. I have tested that mmsegmentation 0.16.0 also support code in 0.11.0, so it won't affect @aelbakry  's work.