### PR TITLE
Fix evaluation bug due to dimensions mismatch.

### DIFF
--- a/runtime/scripts/metric.py
+++ b/runtime/scripts/metric.py
@@ -27,6 +27,7 @@ def intersection_over_union(array_pairs, total=None):
     intersection = 0
     union = 0
     for pred, actual in tqdm(array_pairs, total=total):
+        actual = np.expand_dims(actual, axis=-1)
         invalid_mask = actual == NA_VALUE
         actual = np.ma.masked_array(actual, invalid_mask)
         pred = np.ma.masked_array(pred, invalid_mask)


### PR DESCRIPTION
Currently there's a bug in `runtime/scripts/metric.py` due to dimensions mismatch between `actual` and `pred`. `numpy` broadcasts one of the arrays, affecting the IOU metric.

If I print the following at the moment:
```python
print(actual.shape)
print(pred.shape)
print(np.logical_and(actual, pred).shape)
```
I get
```bash
(512, 512)
(512, 512, 1)
(512, 512, 512)
```

After my fix (this PR), the shapes look alright:
```bash
(512, 512, 1)
(512, 512, 1)
(512, 512, 1)
```

I also ran the evaluation on a poorly trained model and the IOU is different before vs after.
BEFORE: overall score: 0.001961406959297313
AFTER: overall score: 0.0015769566712381285