### PR TITLE
- add numba==0.54.0 for speeding up numpy math operations,

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -44,3 +44,4 @@ dependencies:
     - mmsegmentation==0.16.0
     - tensorflow-cpu==2.6.0
     - segmentation-models==1.0.1
+    - numba==0.54.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -47,3 +47,4 @@ dependencies:
     - mmsegmentation==0.16.0
     - tensorflow-gpu==2.6.0
     - segmentation-models==1.0.1
+    - numba==0.54.0


### PR DESCRIPTION
- I need to add numba package to speed up numpy operations because numba runs numpy operations on GPU instead of CPU.
This package will help reducing online test time for my solution to minutes instead of hours.

PLEASE merge it as soon as possible