### PR TITLE
Correct way to install for lightning-flash[image] after 0.5.0

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -45,3 +45,4 @@ dependencies:
     - tensorflow-cpu==2.6.0
     - segmentation-models==1.0.1
     - numba==0.54.0
+    - lightning-flash==0.5.0

--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -45,4 +45,4 @@ dependencies:
     - tensorflow-cpu==2.6.0
     - segmentation-models==1.0.1
     - numba==0.54.0
-    - lightning-flash==0.5.0
+    - lightning-flash[image]==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -48,3 +48,4 @@ dependencies:
     - tensorflow-gpu==2.6.0
     - segmentation-models==1.0.1
     - numba==0.54.0
+    - lightning-flash==0.5.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -48,4 +48,4 @@ dependencies:
     - tensorflow-gpu==2.6.0
     - segmentation-models==1.0.1
     - numba==0.54.0
-    - lightning-flash==0.5.0
+    - lightning-flash[image]==0.5.0


### PR DESCRIPTION
Sorry for the confusion and prompt reply, to get `flash.image`, this is the correct way of installing. 